### PR TITLE
Add README explaining key update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Reef Technologies SSH Public Keys
+
+This repository stores the public SSH keys of Reef Technologies staff members. The keys are published at [keys.reef.pl](https://keys.reef.pl) via GitHub Pages.
+
+## Adding or Updating Your Key
+
+1. Create a PR adding/updating your key in both `index.md` and `authorized_keys`
+2. Get the PR reviewed and merged
+3. Ask a server admin to update the target server's `~/.ssh/authorized_keys`
+
+## Files
+
+- `index.md` - Human-readable table (rendered at keys.reef.pl)
+- `authorized_keys` - Machine-readable format for direct use
+- `CNAME` - GitHub Pages domain configuration


### PR DESCRIPTION
## Summary
- Adds README.md explaining the purpose of this repo
- Documents that PRs don't auto-deploy to servers
- Clarifies that manual key update is needed after merge

## Context
Discovered during monitoring setup that new team members might not know PRs don't automatically update server access.